### PR TITLE
Optimize caching key creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.forter</groupId>
     <artifactId>storm-data-contracts-parent</artifactId>
-    <version>0.2.17</version>
+    <version>0.2.18</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/storm-data-contracts-testng/pom.xml
+++ b/storm-data-contracts-testng/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>storm-data-contracts-parent</artifactId>
         <groupId>com.forter</groupId>
-        <version>0.2.17</version>
+        <version>0.2.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/storm-data-contracts/pom.xml
+++ b/storm-data-contracts/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>storm-data-contracts-parent</artifactId>
         <groupId>com.forter</groupId>
-        <version>0.2.17</version>
+        <version>0.2.18</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/storm-data-contracts/src/main/java/com/forter/contracts/BaseContractsBoltExecutor.java
+++ b/storm-data-contracts/src/main/java/com/forter/contracts/BaseContractsBoltExecutor.java
@@ -90,21 +90,23 @@ public class BaseContractsBoltExecutor<TInput, TOutput, TContractsBolt extends I
             else {
                 TInput input = (TInput) validatedInputContract.getContract();
 
-                Map<String, Object> cacheKey;
+                Map<String, Object> cacheKeyData;
                 if(data instanceof ObjectNode) {
-                    cacheKey = cacheKeyFilter.createKey((ObjectNode)data);
+                    cacheKeyData = cacheKeyFilter.createKey((ObjectNode)data);
                 } else {
-                    cacheKey = cacheKeyFilter.createKey(input);
+                    cacheKeyData = cacheKeyFilter.createKey(input);
                 }
 
-                Optional<? super TOutput> cachedOutput = this.cache.get(cacheKey);
+                Optional<? super TOutput> cachedOutput = this.cache.get(cacheKeyData);
                 if (cachedOutput.isPresent()) {
                     output = (TOutput) cachedOutput.get();
                 } else {
                     long startTime = System.currentTimeMillis();
                     output = delegate.execute(input);
-                    this.cache.save(output, cacheKey, startTime);
+                    this.cache.save(output, cacheKeyData, startTime);
                 }
+
+                this.reportCacheStatus(cachedOutput.isPresent(), inputTuple);
             }
         } catch (ReportedFailedException cve) { // includes ContractViolationReportedFailedException
             exception = cve;
@@ -195,6 +197,8 @@ public class BaseContractsBoltExecutor<TInput, TOutput, TContractsBolt extends I
     protected CacheDAO<TOutput> createCacheDAO(Map stormConf, TopologyContext context) {
         return new DummyCacheDAO<>();
     }
+
+    protected void reportCacheStatus(Boolean status, Tuple tuple) {}
 
     private void emit(Object id, Object contract, BasicOutputCollector collector) {
         ArrayList<Object> tuple = Lists.newArrayList(id, transformOutput(contract));

--- a/storm-data-contracts/src/main/java/com/forter/contracts/BaseContractsBoltExecutor.java
+++ b/storm-data-contracts/src/main/java/com/forter/contracts/BaseContractsBoltExecutor.java
@@ -89,7 +89,14 @@ public class BaseContractsBoltExecutor<TInput, TOutput, TContractsBolt extends I
             }
             else {
                 TInput input = (TInput) validatedInputContract.getContract();
-                Map<String, Object> cacheKey = cacheKeyFilter.createKey(input);
+
+                Map<String, Object> cacheKey;
+                if(data instanceof ObjectNode) {
+                    cacheKey = cacheKeyFilter.createKey((ObjectNode)data);
+                } else {
+                    cacheKey = cacheKeyFilter.createKey(input);
+                }
+
                 Optional<? super TOutput> cachedOutput = this.cache.get(cacheKey);
                 if (cachedOutput.isPresent()) {
                     output = (TOutput) cachedOutput.get();

--- a/storm-data-contracts/src/main/java/com/forter/contracts/ContractConverter.java
+++ b/storm-data-contracts/src/main/java/com/forter/contracts/ContractConverter.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.base.Throwables;
+import com.sun.corba.se.impl.orbutil.ObjectWriter;
 
 import java.util.Collections;
 import java.util.Map;
@@ -64,6 +65,10 @@ public class ContractConverter {
 
     public Map convertContractToMap(Object contract) {
         return Collections.unmodifiableMap(mapper.convertValue(contract, Map.class));
+    }
+
+    public Map<String, Object> convertObjectNodeToMap(ObjectNode nodes) {
+        return mapper.convertValue(nodes, Map.class);
     }
 
     public String convertContractToJsonString(Object contract) {

--- a/storm-data-contracts/src/main/java/com/forter/contracts/cache/CacheDAO.java
+++ b/storm-data-contracts/src/main/java/com/forter/contracts/cache/CacheDAO.java
@@ -9,8 +9,7 @@ import java.util.Map;
  */
 public interface CacheDAO<TOutput> {
 
-    public Optional<TOutput> get(Map<String, Object> key);
+    Optional<TOutput> get(Map<String, Object> key);
 
-    public void save(TOutput record, Map<String, Object> inputKey, long startTimeMillis);
-
+    void save(TOutput record, Map<String, Object> inputKey, long startTimeMillis);
 }

--- a/storm-data-contracts/src/main/java/com/forter/contracts/cache/CacheKeyFilter.java
+++ b/storm-data-contracts/src/main/java/com/forter/contracts/cache/CacheKeyFilter.java
@@ -1,7 +1,7 @@
 package com.forter.contracts.cache;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.forter.contracts.ContractConverter;
-
 import java.lang.reflect.Field;
 import java.util.*;
 
@@ -21,8 +21,27 @@ public class CacheKeyFilter {
         }
     }
 
+    public Map<String, Object> createKey(ObjectNode input) {
+        //return null if no CacheKey is present
+        if(this.cachedKeys.size() == 0) {
+            return new HashMap<>();
+        }
+
+        Map<String, Object> filteredInput = ContractConverter.instance().convertObjectNodeToMap(input);
+        return createKeyFromMap(filteredInput);
+    }
+
     public Map<String, Object> createKey(Object input) {
+        //return null if no CacheKey is present
+        if(this.cachedKeys.size() == 0) {
+            return new HashMap<>();
+        }
+
         Map<String, Object> filteredInput = new HashMap<>(converter.convertContractToMap(input));
+        return createKeyFromMap(filteredInput);
+    }
+
+    private Map<String, Object> createKeyFromMap(Map<String, Object> filteredInput) {
         Iterator<String> fieldsIterator = filteredInput.keySet().iterator();
         while (fieldsIterator.hasNext()) {
             if (!cachedKeys.contains(fieldsIterator.next())) {
@@ -31,5 +50,6 @@ public class CacheKeyFilter {
         }
         return filteredInput;
     }
+
 
 }


### PR DESCRIPTION
* Added checking for `ObjectNode`. This prevents the double parsing when creating a caching key which might occur if the input happens to be an `ObjectNode` (first to POJO, then to Map again). 
* If there are no fields annotated with `@CacheKey` , the  `createKey()` method will immidately return a empty map instead of going over the whole object.